### PR TITLE
feat: add static page routing

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>About - StudyBeeNotes</title>
+  </head>
+  <body>
+    <h1>About</h1>
+    <p>This is the about page.</p>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -7,5 +7,10 @@
   <body>
     <h1>Welcome</h1>
     <p>Navigate to <a href="/s/">/s</a> to use the proxy.</p>
+    <ul>
+      <li><a href="/">Home</a></li>
+      <li><a href="/about">About</a></li>
+      <!-- Add new static pages here -->
+    </ul>
   </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,12 @@ import { baremuxPath } from "@mercuryworkshop/bare-mux/node";
 const publicPath = fileURLToPath(new URL("../public/", import.meta.url));
 const searchPath = join(publicPath, "s");
 
+const staticPages = [
+  "index",
+  "about",
+  // add additional static pages here
+];
+
 // Wisp Configuration: Refer to the documentation at https://www.npmjs.com/package/@mercuryworkshop/wisp-js
 
 logging.set_level(logging.NONE);
@@ -72,13 +78,20 @@ fastify.register(fastifyStatic, {
 });
 
 fastify.register(fastifyStatic, {
-	root: baremuxPath,
-	prefix: "/baremux/",
-	decorateReply: false,
+        root: baremuxPath,
+        prefix: "/baremux/",
+        decorateReply: false,
+});
+
+staticPages.forEach((page) => {
+  const routePath = page === "index" ? "/" : `/${page}`;
+  fastify.get(routePath, (req, reply) => {
+    return reply.sendFile(`${page}.html`);
+  });
 });
 
 fastify.setNotFoundHandler((res, reply) => {
-	return reply.code(404).type('text/html').sendFile('404.html');
+        return reply.code(404).type('text/html').sendFile('404.html');
 })
 
 fastify.server.on("listening", () => {


### PR DESCRIPTION
## Summary
- create static page list and register clean URL routes
- add about page and navigation links

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af4c5fb4008327b448ba80f22a0e87