### PR TITLE
Handle login PIN as string or number

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,8 +111,9 @@ fastify.post("/attempt-login", async (req, reply) => {
 
   const accounts = await readAccounts();
   const account = accounts[key];
+  const numericCode = Number(code);
 
-  if (!account || account.pin !== code || account.locked) {
+  if (!account || Number.isNaN(numericCode) || account.pin !== numericCode || account.locked) {
     return { success: false };
   }
 


### PR DESCRIPTION
## Summary
- Accept string-form PINs during login and validate after numeric conversion

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af66c0394483279029e878f3861b8f