### PR TITLE
fix: restore /s proxy routing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,15 +75,19 @@ fastify.register(fastifyStatic, {
         decorateReply: true,
 });
 
-fastify.register(fastifyStatic, {
-  root: searchPath,
-  prefix: "/s/",
-  decorateReply: false,
-});
-
-fastify.get("/s", (req, reply) => {
-  return reply.sendFile("index.html", { root: searchPath });
-});
+fastify.register(
+  (app, _, done) => {
+    app.register(fastifyStatic, {
+      root: searchPath,
+      wildcard: false,
+    });
+    app.setNotFoundHandler((req, reply) => {
+      return reply.sendFile("index.html");
+    });
+    done();
+  },
+  { prefix: "/s" },
+);
 
 fastify.register(fastifyStatic, {
   root: scramjetDistPath,


### PR DESCRIPTION
## Summary
- ensure all /s/* paths serve the search app instead of 404

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68af68d9cf988327baa665ce1a4e12c6